### PR TITLE
Fix hover selector for create nav link

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -169,7 +169,7 @@ a {
   font-weight: var(--regular);
 }
 
-.nav-link-create.hover {
+.nav-link-create:hover {
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- fix typo in nav-link-create hover selector

## Testing
- `npm test` *(fails: cypress not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run type-check` *(fails: missing type definition for cypress and node)*