### PR TITLE
Fix CSS variable spacing

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -31,7 +31,7 @@ body {
 
 body {
   font-family: "Source Code Pro", monospace;
-  color: var (--light-black);
+  color: var(--light-black);
   background-color: var(--light-white);
   width: var(--width);
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- remove stray space in CSS variable

## Testing
- `grep -n "var(--light-black)" -n src/styles.css`